### PR TITLE
Update legacy API keys to new cloud API keys and add support for new multiple portfolios feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/__pycache__/
 .vscode/
 test.py
 promptlib/
+coinbase_cloud_api_key.json

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -230,3 +230,18 @@ def getTransactionsSummary(start_date, end_date, user_native_currency='USD', pro
         'contract_expiry_type': contract_expiry_type
     }
     return cb_auth(Method.GET.value, '/api/v3/brokerage/transaction_summary', params)
+
+def listAccounts(limit=49, cursor=None):
+    """
+    Get a list of authenticated accounts for the current user.
+
+    This function uses the GET method to retrieve a list of authenticated accounts from the Coinbase Advanced Trade API.
+
+    :param limit: A pagination limit with default of 49 and maximum of 250. If has_next is true, additional orders are available to be fetched with pagination and the cursor value in the response can be passed as cursor parameter in the subsequent request.
+    :param cursor: Cursor used for pagination. When provided, the response returns responses after this cursor.
+    :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+    """
+    return cb_auth(Method.GET.value, '/api/v3/brokerage/accounts', {'limit': limit, 'cursor': cursor})
+
+def listPortfolios(portfolio_type="UNDEFINED"):
+    return cb_auth(Method.GET.value, '/api/v3/brokerage/portfolios', {'portfolio_type':portfolio_type})

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -16,6 +16,7 @@ class Side(Enum):
 class Method(Enum):
     POST = "POST"
     GET = "GET"
+    DELETE = "DELETE"
 
 
 
@@ -269,4 +270,8 @@ def movePortfolioFunds(value, currencySymbol, source_portfolio_uuid, target_port
 
 def getPortfolioBreakdown(portfolio_uuid):
     return cb_auth(Method.GET.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
+
+def deletePortfolio(portfolio_uuid):
+    # print("Payload being sent to server:", payload)  # For debugging
+    return cb_auth(Method.DELETE.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
 

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from datetime import datetime
 import uuid
 import json
 from cb_auth import CBAuth

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -245,3 +245,23 @@ def listAccounts(limit=49, cursor=None):
 
 def listPortfolios(portfolio_type="UNDEFINED"):
     return cb_auth(Method.GET.value, '/api/v3/brokerage/portfolios', {'portfolio_type':portfolio_type})
+
+def createOrder(name):
+    # print("Payload being sent to server:", payload)  # For debugging
+    return cb_auth(Method.POST.value, '/api/v3/brokerage/portfolios', {"name":name})
+
+def movePortfolioFunds(value, currencySymbol, source_portfolio_uuid, target_portfolio_uuid):
+    payload = {
+        "funds" : {
+            "value" : value,
+            "currency" : currencySymbol
+        },
+        "source_portfolio_uuid" : source_portfolio_uuid,
+        "target_portfolio_uuid" : target_portfolio_uuid
+    }
+
+    return cb_auth(
+        Method.POST.value,
+        '/api/v3/brokerage/portfolios/move_funds',
+        payload
+    )

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -17,6 +17,7 @@ class Method(Enum):
     POST = "POST"
     GET = "GET"
     DELETE = "DELETE"
+    PUT = "PUT"
 
 
 
@@ -274,5 +275,5 @@ def getPortfolioBreakdown(portfolio_uuid):
 def deletePortfolio(portfolio_uuid):
     return cb_auth(Method.DELETE.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
 
-def editPortfolio(portfolio_uuid):
-    return cb_auth(Method.POST.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
+def editPortfolio(portfolio_uuid, name):
+    return cb_auth(Method.PUT.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}', {"name" : name})

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -246,13 +246,39 @@ def listAccounts(limit=49, cursor=None):
     return cb_auth(Method.GET.value, '/api/v3/brokerage/accounts', {'limit': limit, 'cursor': cursor})
 
 def listPortfolios(portfolio_type="UNDEFINED"):
+    """
+       Get a list of all portfolios of a user.
+
+       This function uses the GET method to retrieve a list of authenticated accounts from the Coinbase Advanced Trade API.
+
+       :param portfolio_type: String (optional) | "UNDEFINED", "DEFAULT", "CONSUMER", "INTX"
+       :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+    """
     return cb_auth(Method.GET.value, '/api/v3/brokerage/portfolios', {'portfolio_type':portfolio_type})
 
 def createPortfolio(name):
-    # print("Payload being sent to server:", payload)  # For debugging
+    """
+       Create a portfolio
+
+       This function uses the POST method to create a portfolio within a user account from the Coinbase Advanced Trade API.
+
+       :param name: String : Name of the portfolio
+       :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+   """
     return cb_auth(Method.POST.value, '/api/v3/brokerage/portfolios', {"name":name})
 
 def movePortfolioFunds(value, currencySymbol, source_portfolio_uuid, target_portfolio_uuid):
+    """
+       Transfer funds between portfolios
+
+       This function uses the POST method to move funds from the source portfolio to the target portfolio from the Coinbase Advanced Trade API.
+
+       :param value: String | The value to be moved (i.e. "100")
+       :param currencySymbol: String | The currency symbol (i.e. "BTC", "USD")
+       :param source_portfolio_uuid: String | The uuid of the source portfolio
+       :param target_portfolio_uuid: String | The uuid of the target portfolio
+       :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+    """
     payload = {
         "funds" : {
             "value" : value,
@@ -269,10 +295,35 @@ def movePortfolioFunds(value, currencySymbol, source_portfolio_uuid, target_port
     )
 
 def getPortfolioBreakdown(portfolio_uuid):
+    """
+       Get the breakdown of a portfolio by portfolio ID
+
+       This function uses the GET method to retrieve a detailed breakdown of a portfolio from the Coinbase Advanced Trade API.
+
+       :param portfolio_uuid: String : UUID of the desired portfolio
+       :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+    """
     return cb_auth(Method.GET.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
 
 def deletePortfolio(portfolio_uuid):
+    """
+        Delete portfolio by portfolio ID
+
+        This function uses the DELETE method to delete a portfolio from the Coinbase Advanced Trade API.
+
+        :param portfolio_uuid: String : UUID of portfolio
+        :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+    """
     return cb_auth(Method.DELETE.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
 
 def editPortfolio(portfolio_uuid, name):
+    """
+        Modify a portfolio name by portfolio ID
+
+        This function uses the PUT method to edit the name of a portfolio within a user account from the Coinbase Advanced Trade API.
+
+        :param portfolio_uuid: String : UUID of portfolio
+        :param name: String : New name of the portfolio
+        :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
+    """
     return cb_auth(Method.PUT.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}', {"name" : name})

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -18,6 +18,7 @@ class Method(Enum):
     GET = "GET"
 
 
+
 def generate_client_order_id():
     return str(uuid.uuid4())
 
@@ -265,3 +266,7 @@ def movePortfolioFunds(value, currencySymbol, source_portfolio_uuid, target_port
         '/api/v3/brokerage/portfolios/move_funds',
         payload
     )
+
+def getPortfolioBreakdown(portfolio_uuid):
+    return cb_auth(Method.GET.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
+

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -233,18 +233,6 @@ def getTransactionsSummary(start_date, end_date, user_native_currency='USD', pro
     }
     return cb_auth(Method.GET.value, '/api/v3/brokerage/transaction_summary', params)
 
-def listAccounts(limit=49, cursor=None):
-    """
-    Get a list of authenticated accounts for the current user.
-
-    This function uses the GET method to retrieve a list of authenticated accounts from the Coinbase Advanced Trade API.
-
-    :param limit: A pagination limit with default of 49 and maximum of 250. If has_next is true, additional orders are available to be fetched with pagination and the cursor value in the response can be passed as cursor parameter in the subsequent request.
-    :param cursor: Cursor used for pagination. When provided, the response returns responses after this cursor.
-    :return: A dictionary containing the response from the server. A successful response will return a 200 status code. An unexpected error will return a default error response.
-    """
-    return cb_auth(Method.GET.value, '/api/v3/brokerage/accounts', {'limit': limit, 'cursor': cursor})
-
 def listPortfolios(portfolio_type="UNDEFINED"):
     """
        Get a list of all portfolios of a user.

--- a/coinbase_advanced_trader/coinbase_client.py
+++ b/coinbase_advanced_trader/coinbase_client.py
@@ -248,7 +248,7 @@ def listAccounts(limit=49, cursor=None):
 def listPortfolios(portfolio_type="UNDEFINED"):
     return cb_auth(Method.GET.value, '/api/v3/brokerage/portfolios', {'portfolio_type':portfolio_type})
 
-def createOrder(name):
+def createPortfolio(name):
     # print("Payload being sent to server:", payload)  # For debugging
     return cb_auth(Method.POST.value, '/api/v3/brokerage/portfolios', {"name":name})
 
@@ -272,6 +272,7 @@ def getPortfolioBreakdown(portfolio_uuid):
     return cb_auth(Method.GET.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
 
 def deletePortfolio(portfolio_uuid):
-    # print("Payload being sent to server:", payload)  # For debugging
     return cb_auth(Method.DELETE.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')
 
+def editPortfolio(portfolio_uuid):
+    return cb_auth(Method.POST.value, f'/api/v3/brokerage/portfolios/{portfolio_uuid}')

--- a/coinbase_advanced_trader/config.py
+++ b/coinbase_advanced_trader/config.py
@@ -1,5 +1,5 @@
 import os
-from coinbase_advanced_trader.cb_auth import CBAuth
+from cb_auth import CBAuth
 
 API_KEY = None
 API_SECRET = None

--- a/coinbase_advanced_trader/main.py
+++ b/coinbase_advanced_trader/main.py
@@ -1,0 +1,18 @@
+from coinbase_client import listAccounts, listPortfolios, getPortfolioBreakdown
+from config import set_api_credentials
+def main():
+    set_api_credentials()
+
+    #List accounts
+    print(listAccounts())
+
+    #ListPortfolios
+    portfolioList = listPortfolios()
+    print(portfolioList)
+
+    #Portfolio breakdown (of first portfolio)
+    portfolio_uuid = portfolioList['portfolios'][0]['uuid']
+    print(getPortfolioBreakdown(portfolio_uuid))
+
+if __name__ == "__main__":
+    main()

--- a/coinbase_advanced_trader/main.py
+++ b/coinbase_advanced_trader/main.py
@@ -1,18 +1,17 @@
-from coinbase_client import listAccounts, listPortfolios, getPortfolioBreakdown
+from coinbase_client import (
+    listAccounts,
+    listPortfolios
+)
 from config import set_api_credentials
+
 def main():
     set_api_credentials()
 
-    #List accounts
+    # List accounts
     print(listAccounts())
 
     #ListPortfolios
-    portfolioList = listPortfolios()
-    print(portfolioList)
-
-    #Portfolio breakdown (of first portfolio)
-    portfolio_uuid = portfolioList['portfolios'][0]['uuid']
-    print(getPortfolioBreakdown(portfolio_uuid))
+    print(listPortfolios())
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+PyJWT
+cryptography


### PR DESCRIPTION
Coinbase is slowly moving away from the current API keys (legacy) and to cloud API keys which:
- use JWT 
- add support for their new multiple portfolio feature
- still support all previous legacy endpoints

Changes made include:
- modify _cb_auth.py_ to use cloud API keys
- add multiple portfolio functions to _coinbase_client.py_ (all other functions are untouched!)
