### PR TITLE
Add logic to include keys

### DIFF
--- a/include.py
+++ b/include.py
@@ -1,0 +1,12 @@
+import json
+
+def load_api_credentials(json_file_path='cdp_api_key.json'):
+    # Read the JSON file
+    with open(json_file_path, 'r') as file:
+        data = json.load(file)
+    
+    # Extract the API key and secret
+    api_key = data['name']
+    api_secret = data['privateKey']
+    
+    return api_key, api_secret


### PR DESCRIPTION
Coinbase will download **cdp_api_key.json** file which has the keys needed.  This pull request just opens that file by default so you can re-use the keys easier in multiple scripts instead of having to copy them in each.

To do so:

```
from coinbase_advanced_trader.enhanced_rest_client import EnhancedRESTClient
from include import load_api_credentials

# Load API credentials
api_key, api_secret = load_api_credentials()    # Default case opens cdp_api_key.json
#api_key, api_secret = load_api_credentials( 'foo.json' )    # Optional case opens a file name given, different keys to open different CB portfolios

# use loaded keys
client = EnhancedRESTClient(api_key=api_key, api_secret=api_secret)

product_info = client.get_product(product_id="BTC-USDC")

...

```