### PR TITLE
Add error handing in OrderService._place_limit_order()

### DIFF
--- a/coinbase_advanced_trader/services/order_service.py
+++ b/coinbase_advanced_trader/services/order_service.py
@@ -221,6 +221,7 @@ class OrderService:
                 adjusted_price
             )
             self._log_order_result(order_response, product_id, base_size, adjusted_price, side)
+            logger.info(f"Order: {order}")
             return order
         
         else:
@@ -228,7 +229,7 @@ class OrderService:
             For some reason, the order placement failed. Log and return "something(?)"
             """
             order_error = order_response['error_response']["error"]
-            logger.error(f"Order placed resulted in {order_error}")
+            logger.info(f"Order placed resulted in {order_error}")
 
             """
             Build an Order object with the error_response.error as the the
@@ -250,15 +251,15 @@ class OrderService:
 
             match order_error:
                 case 'INSUFFICIENT_FUND':
-                    logger.debug("Do NSF stuff here.")
+                    logger.info("Do NSF stuff here.")
                     return error_order
 
                 case 'INVALID_LIMIT_PRICE_POST_ONLY':
-                    logger.debug("Do INVALID_LIMIT_PRICE_POST_ONLY stuff here")
+                    logger.info("Do INVALID_LIMIT_PRICE_POST_ONLY stuff here")
                     return error_order
 
                 case 'INVALID_PRICE_PRECISION':
-                    logger.debug("Do INVALID_PRICE_PRECISION stuff here.")
+                    logger.info("Do INVALID_PRICE_PRECISION stuff here.")
                     return error_order
 
                 case _:
@@ -313,4 +314,4 @@ class OrderService:
                          f"Reason: {failure_reason}. "
                          f"Preview failure reason: {preview_failure_reason}")
         
-        logger.debug(f"Coinbase response: {order}")
+        logger.info(f"Coinbase response: {order}")

--- a/coinbase_advanced_trader/services/order_service.py
+++ b/coinbase_advanced_trader/services/order_service.py
@@ -271,4 +271,4 @@ class OrderService:
                          f"Reason: {failure_reason}. "
                          f"Preview failure reason: {preview_failure_reason}")
         
-        logger.info(f"Coinbase response: {order}")
+        logger.debug(f"Coinbase response: {order}")

--- a/coinbase_advanced_trader/services/order_service.py
+++ b/coinbase_advanced_trader/services/order_service.py
@@ -210,7 +210,7 @@ class OrderService:
             )
 
             if not order_response['success']:
-                error_response = order_response.get('error_response', {})
+                error_response = order_response.to_dict().get('error_response', {})
                 error_message = error_response.get('message', 'Unknown error')
                 preview_failure_reason = error_response.get('preview_failure_reason', 'Unknown')
                 error_log = (f"Failed to place a limit order. "

--- a/coinbase_advanced_trader/services/order_service.py
+++ b/coinbase_advanced_trader/services/order_service.py
@@ -207,17 +207,78 @@ class OrderService:
             str(base_size),
             str(adjusted_price)
         )
+
+        if order_response["success"]:
+            """
+            The order was successful. Process, log, and return.
+            """
+            order = self._build_order(
+                order_response['success_response']['order_id'],
+                product_id,
+                side,
+                OrderType.LIMIT,
+                base_size,
+                adjusted_price
+            )
+            self._log_order_result(order_response, product_id, base_size, adjusted_price, side)
+            return order
         
+        else:
+            """
+            For some reason, the order placement failed. Log and return "something(?)"
+            """
+            order_error = order_response['error_response']["error"]
+            logger.error(f"Order placed resulted in {order_error}")
+
+            """
+            Build an Order object with the error_response.error as the the
+            order_id. This convention allows to return an order and be able
+            to handle issues with order placement.
+            """
+
+            error_order_id = 'ORDER_ERROR_'+order_error
+
+            error_order = self._build_order(
+                error_order_id, 
+                product_id, 
+                side, 
+                OrderType.LIMIT, 
+                base_size, 
+                adjusted_price, 
+                'error'
+            )
+
+            match order_error:
+                case 'INSUFFICIENT_FUND':
+                    logger.debug("Do NSF stuff here.")
+                    return error_order
+
+                case 'INVALID_LIMIT_PRICE_POST_ONLY':
+                    logger.debug("Do INVALID_LIMIT_PRICE_POST_ONLY stuff here")
+                    return error_order
+
+                case 'INVALID_PRICE_PRECISION':
+                    logger.debug("Do INVALID_PRICE_PRECISION stuff here.")
+                    return error_order
+
+                case _:
+                    logger.error("An unprocessed order error occurred.")
+                    return error_order
+                    
+    def _build_order(id, product_id, side, type, size, price, status = 'pending') -> Order:
+        """
+        Helper function to build an Order object. Include 'status' parameter
+        to allow for error orders.
+        """
         order = Order(
-            id=order_response['success_response']['order_id'],
-            product_id=product_id,
-            side=side,
-            type=OrderType.LIMIT,
-            size=base_size,
-            price=adjusted_price
+                id=id,
+                product_id=product_id,
+                side=side,
+                type=type,
+                size=size,
+                price=price,
+                status=status
         )
-        
-        self._log_order_result(order_response, product_id, base_size, adjusted_price, side)
         return order
     
     def _log_order_result(self, order: Dict[str, Any], product_id: str, amount: Any, price: Any = None, side: OrderSide = None) -> None:


### PR DESCRIPTION
As of main commit 72d9e38 the code for the `_place_limit_order()` method in the OrderService class in `order_service.py` throws an exception if `limit_order_gtc_[buy|sell]` errors out. 

This pull request adds checking in `_place_limit_order()` that is similar to the checking located in `OrderClass.fiat_market_sell()`. 

This code has been tested with both a `fiat_limit_buy` and a `fiat_limit_sell` for an `INSUFFICIENT_FUND` case, and provides a unit test for the new code.